### PR TITLE
Add test.js which handles all testing logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,17 @@ $ openapi-forge forge
 
 Using the one command below you can automatically run the testing:
 ~~~
-npm test
+npm test [{featurePath} [{generatorPath}]]
 ~~~
+The two arguments are optional.
+
+You must give a featurePath if you want to give a generatorPath.
+
+Default values:
+
+featurePath: ../openapi-forge/features/*.feature
+
+generatorPath: openapi-forge/src/generate
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ openapi-forge forge
 
 Using the one command below you can automatically run the testing:
 ~~~
-npm test [{featurePath} [{generatorPath}]]
+npm test [{featurePath} [{generatorPath}] ]
 ~~~
 The two arguments are optional.
 

--- a/cucumber.js
+++ b/cucumber.js
@@ -3,7 +3,7 @@
 // Retrieve the path to feature paths from cl arguments of cucumber-js
 const featurePath = process.argv.slice(2)[2];
 
-if (featurePath === undefined) {
+if (!featurePath) {
   throw new Error(`You must provide a path to the feature files.`);
 }
 

--- a/cucumber.js
+++ b/cucumber.js
@@ -1,6 +1,14 @@
 // cucumber.js
+
+// Retrieve the path to feature paths from cl arguments of cucumber-js
+const featurePath = process.argv.slice(2)[2];
+
+if (featurePath === undefined) {
+  throw new Error(`You must provide a path to the feature files.`);
+}
+
 let common = [
-  "node_modules/openapi-forge/features/*.feature", // Specify our feature files
+  featurePath, // Specify our feature files
   "--require-module ts-node/register", // Load TypeScript module
   "--require features/support/*.ts", // Load step definitions
 ].join(" ");

--- a/features/support/base.ts
+++ b/features/support/base.ts
@@ -3,7 +3,7 @@
 // Retrieve the path to generate.js from cl arguments of cucumber-js
 const generatePath = process.argv.slice(2)[3];
 
-if (generatePath === undefined) {
+if (!generatePath) {
   throw new Error(`You must provide a path to generate.js.`);
 }
 

--- a/features/support/base.ts
+++ b/features/support/base.ts
@@ -1,5 +1,13 @@
 // TODO: add type definitions to the generator
-const generate = require("openapi-forge/src/generate");
+
+// Retrieve the path to generate.js from cl arguments of cucumber-js
+const generatePath = process.argv.slice(2)[3];
+
+if (generatePath === undefined) {
+  throw new Error(`You must provide a path to generate.js.`);
+}
+
+const generate = require(generatePath);
 
 import { rmSync, existsSync } from "fs";
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "scripts": {
-    "test": "./node_modules/.bin/cucumber-js -p default"
+    "test": "node test"
   },
   "license": "MIT",
   "devDependencies": {
@@ -16,6 +16,7 @@
     "cucumber-tsflow": "^3.2.0",
     "openapi-forge": "github:ColinEberhardt/openapi-forge#6be3962bc263948237f71689b2df7ba73e116a55",
     "ts-node": "^8.0.3",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "shelljs": "^0.8.5"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+const shell = require("shelljs");
+
+// Extract cl arguments
+const clArgs = process.argv.slice(2);
+
+// Retrieve the path to feature paths from cl arguments of 'npm test', use default value if none given
+featurePath = clArgs[0] || "../openapi-forge/features/*.feature";
+
+// Retrieve the path to generate.js from cl arguments of 'npm test', use default value if none given
+generatePath = clArgs[1] || "openapi-forge/src/generate";
+
+// Pass both paths to cucumber-js which spawns another node process to handle the testing.
+shell.exec(`.\\node_modules\\.bin\\cucumber-js -p default ${featurePath} ${generatePath}`);


### PR DESCRIPTION
In response to our discussion on the test-generators command in the forge I have changed how variable file paths are configured in the generators. 

I took the approach of using cl arguments that are then passed onto the node process that runs the testing (2 processes are run during testing. 1 for starting the tests, the other for running the tests).

A separate test.js file is run that kicks off the testing rather than directly calling the cucumber testing allows for the passing of cl arguments.

Default values are used if no cl arguments given. This results in no change to how the existing testing is run and allows for a bespoke directory configuration of forge and generator.

**Changes**
- Allow variable file paths to feature files and generate.js when using npm test via cl arguments.
- Update readme.md.
- Add shelljs as a dev dependency.