### PR TITLE
Fix testing when using custom file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,22 @@ $ openapi-forge forge
 ~~~
 
 ## Testing
+There are two scripts that can be used for testing, one that uses preset values for file paths to *.feature files and the generate.js file of the forge:
 
-Using the one command below you can automatically run the testing:
+Using default values:
 ~~~
-npm test [{featurePath} {generatorPath}]
-~~~
-The two arguments are optional.
-
-You must give a featurePath and a generatorPath if you want custom paths.
-
-Default values:
+npm run test:defaultPaths
+~~
+This method uses:
 
 featurePath: node_modules/openapi-forge/features/*.feature
 
 generatorPath: openapi-forge/src/generate
+
+The second script requires values for the featurePath & generatePath:
+~~~
+npm test {featurePath} {generatorPath}
+~~~
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "description": "",
   "scripts": {
-    "test": "\"./node_modules/.bin/cucumber-js\" -p default \"node_modules/openapi-forge/features/*.feature\" \"openapi-forge/src/generate\""
+    "test": "\"./node_modules/.bin/cucumber-js\" -p default",
+    "test:defaultPath": "\"./node_modules/.bin/cucumber-js\" -p default \"node_modules/openapi-forge/features/*.feature\" \"openapi-forge/src/generate\""
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Fix for https://github.com/ScottLogic/openapi-forge/issues/79

Removed logic that determines if the default value for featurePath and generatePath should be used. Instead two scripts are now exposed.

'test' : This needs a featurePath & generatePath given 
'test:defaultPath' : This uses the default values for featurePath & generatePath

I opted for this convention over 'test' & 'test:customPath' because the addition of writing ':defaultPath' prevents the need for you to write the two paths so it still produces a optimised route. 

If you used ':customPath' the user needs to write additional word in the test script name and also the two custom paths and therefore the command is even longer. Also test-generators uses 'test' so it reduces the code changes needed for this new script configuration to work.