### PR TITLE
fixed a few markdown issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,42 +25,42 @@ $ openapi-forge forge
 
 ## Testing
 
-There are two scripts that can be used for testing, one that uses preset values for file paths to \*.feature files and the generate.js file of the forge:
+There are two scripts that can be used for testing, one that uses preset values for file paths to feature files and the `generate.js` file of the forge:
 
 Using default values:
 
 ```
 npm run test:defaultPaths
-~~
-This method uses:
-
-featurePath: node_modules/openapi-forge/features/*.feature
-
-generatorPath: openapi-forge/src/generate
-
-The second script requires values for the featurePath & generatePath:
 ```
 
-npm test {featurePath} {generatorPath}
+This method uses:
 
+ - `featurePath` - `node_modules/openapi-forge/features/*.feature`
+ - `generatorPath` - `openapi-forge/src/generate`
+
+The second script requires values for the featurePath & generatePath:
+
+```
+npm test {featurePath} {generatorPath}
 ```
 
 ## Linting
 
 Two scripts are available to help you find linting errors:
 
-~~~
+```
 npm run eslint:check
-~~~
-This runs eslint in check mode which will raise errors found but not try and fix them.
-This is also ran on a PR and a push to main. It will fail if any errors were found.
+```
 
-~~~
+This runs eslint in check mode which will raise errors found but not try and fix them. This is also ran on a PR and a push to main. It will fail if any errors were found.
+
+```
 npm run eslint:write
-~~~
+```
+
 This runs eslint in write mode which will raise errors found and try to fix them.
 
 ## Notes
 
 The openapi-forge dependency is pointing to commit:0fb044b3a2808e8faf82786f168a12763f5aaeca. If openapi-forge is updated and openapi-forge-typescript requires this updated version then the commit reference in package.json will have to be updated. This is a temporary measure and will be fixed once the packages are properly versioned and hosted on npm.
-```
+

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ npm run test:defaultPaths
 
 This method uses:
 
- - `featurePath` - `node_modules/openapi-forge/features/*.feature`
- - `generatorPath` - `openapi-forge/src/generate`
+- `featurePath` - `node_modules/openapi-forge/features/*.feature`
+- `generatorPath` - `openapi-forge/src/generate`
 
 The second script requires values for the featurePath & generatePath:
 
@@ -63,4 +63,3 @@ This runs eslint in write mode which will raise errors found and try to fix them
 ## Notes
 
 The openapi-forge dependency is pointing to commit:0fb044b3a2808e8faf82786f168a12763f5aaeca. If openapi-forge is updated and openapi-forge-typescript requires this updated version then the commit reference in package.json will have to be updated. This is a temporary measure and will be fixed once the packages are properly versioned and hosted on npm.
-


### PR DESCRIPTION
.. and the reference to `npm run test:defaultPath~s~`