### PR TITLE
Use npm modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,3 @@ npm run eslint:write:all
 ```
 
 This runs eslint in write mode which will raise errors found and try to fix them.
-
-## Notes
-
-The openapi-forge dependency is pointing to commit:0fb044b3a2808e8faf82786f168a12763f5aaeca. If openapi-forge is updated and openapi-forge-typescript requires this updated version then the commit reference in package.json will have to be updated. This is a temporary measure and will be fixed once the packages are properly versioned and hosted on npm.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,7 @@
         "cucumber-tsflow": "^3.2.0",
         "eslint": "^8.24.0",
         "husky": "^8.0.1",
-        "openapi-forge": "github:ColinEberhardt/openapi-forge#1cd7b107fca832e286c40f9e8ec1e483e368b624",
-        "prettier": "^2.7.1",
+        "openapi-forge": "^1.0.0",
         "semantic-release": "^19.0.5",
         "ts-node": "^8.0.3",
         "typescript": "^4.7.4"
@@ -6884,11 +6883,10 @@
       }
     },
     "node_modules/openapi-forge": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/ColinEberhardt/openapi-forge.git#1cd7b107fca832e286c40f9e8ec1e483e368b624",
-      "integrity": "sha512-AL9JNKL6CPGQ7YupkJosoY1ezbnrofGX+qjM+e3XJABIDZqVrUGmqn4G3lgxlbbS6VBcHqcRewLrrYNTf0s44Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/openapi-forge/-/openapi-forge-1.0.1.tgz",
+      "integrity": "sha512-fzUQsa0dPt14cg2MhWgRKkMOBq4dV+QnoEyVKsbVL8vAjQwVrKiag2DJQZ6pGPggK0CwXsg6k4DrIscOVd+4uw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.0",
         "commander": "^9.2.0",
@@ -6902,6 +6900,9 @@
       },
       "bin": {
         "openapi-forge": "src/index.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/openapi-forge/node_modules/brace-expansion": {
@@ -13749,10 +13750,10 @@
       }
     },
     "openapi-forge": {
-      "version": "git+ssh://git@github.com/ColinEberhardt/openapi-forge.git#1cd7b107fca832e286c40f9e8ec1e483e368b624",
-      "integrity": "sha512-AL9JNKL6CPGQ7YupkJosoY1ezbnrofGX+qjM+e3XJABIDZqVrUGmqn4G3lgxlbbS6VBcHqcRewLrrYNTf0s44Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/openapi-forge/-/openapi-forge-1.0.1.tgz",
+      "integrity": "sha512-fzUQsa0dPt14cg2MhWgRKkMOBq4dV+QnoEyVKsbVL8vAjQwVrKiag2DJQZ6pGPggK0CwXsg6k4DrIscOVd+4uw==",
       "dev": true,
-      "from": "openapi-forge@github:ColinEberhardt/openapi-forge#1cd7b107fca832e286c40f9e8ec1e483e368b624",
       "requires": {
         "@apidevtools/swagger-parser": "^10.1.0",
         "commander": "^9.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "openapi-forge-typescript",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "cucumber-tsflow": "^3.2.0",
         "eslint": "^8.24.0",
         "husky": "^8.0.1",
-        "openapi-forge": "^1.0.0",
+        "openapi-forge": "latest",
         "semantic-release": "^19.0.5",
         "ts-node": "^8.0.3",
         "typescript": "^4.7.4"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cucumber-tsflow": "^3.2.0",
     "eslint": "^8.24.0",
     "husky": "^8.0.1",
-    "openapi-forge": "github:ColinEberhardt/openapi-forge#1cd7b107fca832e286c40f9e8ec1e483e368b624",
+    "openapi-forge": "^1.0.0",
     "semantic-release": "^19.0.5",
     "ts-node": "^8.0.3",
     "typescript": "^4.7.4"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cucumber-tsflow": "^3.2.0",
     "eslint": "^8.24.0",
     "husky": "^8.0.1",
-    "openapi-forge": "^1.0.0",
+    "openapi-forge": "latest",
     "semantic-release": "^19.0.5",
     "ts-node": "^8.0.3",
     "typescript": "^4.7.4"


### PR DESCRIPTION
PR for issue: https://github.com/ScottLogic/openapi-forge/issues/53
- Change OpenAPI-Forge dependency to use the published npm module.
- I have used the versioning of "latest". 