### PR TITLE
test: remove forge dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,14 @@ jobs:
       - name: Install Node.js dependencies
         run: npm install
 
+      - name: Install Forge
+        run: |
+          cd ..
+          git clone https://github.com/ScottLogic/openapi-forge.git
+          cd openapi-forge
+          npm install
+          npm install -g
+
       - name: Test generator
         run: npm run test:defaultPath
         continue-on-error: true

--- a/features/support/api.ts
+++ b/features/support/api.ts
@@ -182,7 +182,7 @@ export class ModelSteps extends BaseModelStep {
   @then(/the method "(.*)" should be present in the api file with tag "(.*)"/)
   public checkMethodExists(methodName: string, tag: string) {
     fs.existsSync(`../api/api${getTagFileName(tag)}.ts`);
-    const apiFile = require(`../api/api${tag}.ts`);
+    const apiFile = require(`../api/api${getTagFileName(tag)}.ts`);
 
     const module = new apiFile.default();
 
@@ -194,7 +194,7 @@ export class ModelSteps extends BaseModelStep {
   )
   public checkMethodDoesNotExist(methodName: string, tag: string) {
     fs.existsSync(`../api/api${getTagFileName(tag)}.ts`);
-    const apiFile = require(`../api/api${tag}.ts`);
+    const apiFile = require(`../api/api${getTagFileName(tag)}.ts`);
 
     const module = new apiFile.default();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "openapi-forge-typescript",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,53 +26,12 @@
         "cucumber-tsflow": "^3.2.0",
         "eslint": "^8.24.0",
         "husky": "^8.0.1",
-        "openapi-forge": "latest",
         "semantic-release": "^19.0.5",
         "ts-node": "^8.0.3",
         "typescript": "^4.7.4"
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "node_modules/@apidevtools/openapi-schemas": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "9.0.6",
-        "@apidevtools/openapi-schemas": "^2.1.0",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "ajv": "^8.6.3",
-        "ajv-draft-04": "^1.0.0",
-        "call-me-maybe": "^1.0.1"
-      },
-      "peerDependencies": {
-        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -617,11 +576,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@exodus/schemasafe": {
-      "version": "1.0.0-rc.7",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.10.7",
       "dev": true,
@@ -676,11 +630,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1381,19 +1330,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
@@ -1458,14 +1394,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
     },
     "node_modules/argv-formatter": {
       "version": "1.0.0",
@@ -1571,11 +1499,6 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.1",
       "dev": true,
       "license": "MIT"
     },
@@ -2308,11 +2231,6 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "node_modules/es6-promise": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/es6-symbol": {
       "version": "3.1.3",
       "dev": true,
@@ -2815,11 +2733,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "dev": true,
@@ -3217,11 +3130,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/http2-client": {
-      "version": "1.3.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -3330,14 +3238,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/into-stream": {
       "version": "6.0.0",
@@ -3523,18 +3423,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
-    },
-    "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -4098,25 +3986,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-fetch-h2": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "http2-client": "^1.2.5"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/node-readfiles": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es6-promise": "^3.2.1"
       }
     },
     "node_modules/normalize-package-data": {
@@ -6749,95 +6618,6 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/oas-kit-common": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "fast-safe-stringify": "^2.0.7"
-      }
-    },
-    "node_modules/oas-linter": {
-      "version": "3.2.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@exodus/schemasafe": "^1.0.0-rc.2",
-        "should": "^13.2.1",
-        "yaml": "^1.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-      }
-    },
-    "node_modules/oas-linter/node_modules/yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/oas-resolver": {
-      "version": "2.5.6",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "node-fetch-h2": "^2.3.0",
-        "oas-kit-common": "^1.0.8",
-        "reftools": "^1.1.9",
-        "yaml": "^1.10.0",
-        "yargs": "^17.0.1"
-      },
-      "bin": {
-        "resolve": "resolve.js"
-      },
-      "funding": {
-        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-      }
-    },
-    "node_modules/oas-resolver/node_modules/yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/oas-schema-walker": {
-      "version": "1.1.5",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "funding": {
-        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-      }
-    },
-    "node_modules/oas-validator": {
-      "version": "5.0.8",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "call-me-maybe": "^1.0.1",
-        "oas-kit-common": "^1.0.8",
-        "oas-linter": "^3.2.2",
-        "oas-resolver": "^2.5.6",
-        "oas-schema-walker": "^1.1.5",
-        "reftools": "^1.1.9",
-        "should": "^13.2.1",
-        "yaml": "^1.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-      }
-    },
-    "node_modules/oas-validator/node_modules/yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "dev": true,
@@ -6868,62 +6648,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/openapi-forge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/openapi-forge/-/openapi-forge-1.0.1.tgz",
-      "integrity": "sha512-fzUQsa0dPt14cg2MhWgRKkMOBq4dV+QnoEyVKsbVL8vAjQwVrKiag2DJQZ6pGPggK0CwXsg6k4DrIscOVd+4uw==",
-      "dev": true,
-      "dependencies": {
-        "@apidevtools/swagger-parser": "^10.1.0",
-        "commander": "^9.2.0",
-        "handlebars": "^4.7.7",
-        "minimatch": "^5.1.0",
-        "node-fetch": "^2.6.7",
-        "prettier": "^2.7.1",
-        "shelljs": "^0.8.5",
-        "swagger2openapi": "^7.0.8",
-        "yaml": "^2.1.1"
-      },
-      "bin": {
-        "openapi-forge": "src/index.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/openapi-forge/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/openapi-forge/node_modules/commander": {
-      "version": "9.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/openapi-forge/node_modules/minimatch": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/openapi-types": {
-      "version": "12.0.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -7468,16 +7192,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -7507,14 +7221,6 @@
       "dev": true,
       "dependencies": {
         "esprima": "~4.0.0"
-      }
-    },
-    "node_modules/reftools": {
-      "version": "1.1.9",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "funding": {
-        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -7895,70 +7601,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/should": {
-      "version": "13.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-equal": "^2.0.0",
-        "should-format": "^3.0.3",
-        "should-type": "^1.4.0",
-        "should-type-adaptors": "^1.0.1",
-        "should-util": "^1.0.0"
-      }
-    },
-    "node_modules/should-equal": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.4.0"
-      }
-    },
-    "node_modules/should-format": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.3.0",
-        "should-type-adaptors": "^1.0.1"
-      }
-    },
-    "node_modules/should-type": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/should-type-adaptors": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.3.0",
-        "should-util": "^1.0.0"
-      }
-    },
-    "node_modules/should-util": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -8138,11 +7780,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/stack-chain": {
       "version": "2.0.0",
@@ -8326,40 +7963,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/swagger2openapi": {
-      "version": "7.0.8",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "call-me-maybe": "^1.0.1",
-        "node-fetch": "^2.6.1",
-        "node-fetch-h2": "^2.3.0",
-        "node-readfiles": "^0.2.0",
-        "oas-kit-common": "^1.0.8",
-        "oas-resolver": "^2.5.6",
-        "oas-schema-walker": "^1.1.5",
-        "oas-validator": "^5.0.8",
-        "reftools": "^1.1.9",
-        "yaml": "^1.10.0",
-        "yargs": "^17.0.1"
-      },
-      "bin": {
-        "boast": "boast.js",
-        "oas-validate": "oas-validate.js",
-        "swagger2openapi": "swagger2openapi.js"
-      },
-      "funding": {
-        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-      }
-    },
-    "node_modules/swagger2openapi/node_modules/yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/temp-dir": {
@@ -8840,14 +8443,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.5.1",
       "dev": true,
@@ -8934,36 +8529,6 @@
     }
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.6",
-      "dev": true,
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "@apidevtools/openapi-schemas": {
-      "version": "2.1.0",
-      "dev": true
-    },
-    "@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "dev": true
-    },
-    "@apidevtools/swagger-parser": {
-      "version": "10.1.0",
-      "dev": true,
-      "requires": {
-        "@apidevtools/json-schema-ref-parser": "9.0.6",
-        "@apidevtools/openapi-schemas": "^2.1.0",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "ajv": "^8.6.3",
-        "ajv-draft-04": "^1.0.0",
-        "call-me-maybe": "^1.0.1"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -9369,10 +8934,6 @@
         }
       }
     },
-    "@exodus/schemasafe": {
-      "version": "1.0.0-rc.7",
-      "dev": true
-    },
     "@humanwhocodes/config-array": {
       "version": "0.10.7",
       "dev": true,
@@ -9411,10 +8972,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "@jsdevtools/ono": {
-      "version": "7.1.3",
-      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -9893,11 +9450,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ajv-draft-04": {
-      "version": "1.0.0",
-      "dev": true,
-      "requires": {}
-    },
     "ansi-escapes": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
@@ -9939,13 +9491,6 @@
     "arg": {
       "version": "4.1.3",
       "dev": true
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
     },
     "argv-formatter": {
       "version": "1.0.0",
@@ -10027,10 +9572,6 @@
     },
     "buffer-from": {
       "version": "1.1.2",
-      "dev": true
-    },
-    "call-me-maybe": {
-      "version": "1.0.1",
       "dev": true
     },
     "callsites": {
@@ -10566,10 +10107,6 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "es6-promise": {
-      "version": "3.3.1",
-      "dev": true
-    },
     "es6-symbol": {
       "version": "3.1.3",
       "dev": true,
@@ -10902,10 +10439,6 @@
       "version": "2.0.6",
       "dev": true
     },
-    "fast-safe-stringify": {
-      "version": "2.1.1",
-      "dev": true
-    },
     "fastq": {
       "version": "1.13.0",
       "dev": true,
@@ -11171,10 +10704,6 @@
         "debug": "4"
       }
     },
-    "http2-client": {
-      "version": "1.3.5",
-      "dev": true
-    },
     "https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -11239,10 +10768,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
-    },
-    "interpret": {
-      "version": "1.4.0",
       "dev": true
     },
     "into-stream": {
@@ -11372,14 +10897,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
-    },
-    "js-yaml": {
-      "version": "3.14.1",
-      "dev": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -11795,20 +11312,6 @@
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
-      }
-    },
-    "node-fetch-h2": {
-      "version": "2.3.0",
-      "dev": true,
-      "requires": {
-        "http2-client": "^1.2.5"
-      }
-    },
-    "node-readfiles": {
-      "version": "0.2.0",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^3.2.1"
       }
     },
     "normalize-package-data": {
@@ -13646,69 +13149,6 @@
         }
       }
     },
-    "oas-kit-common": {
-      "version": "1.0.8",
-      "dev": true,
-      "requires": {
-        "fast-safe-stringify": "^2.0.7"
-      }
-    },
-    "oas-linter": {
-      "version": "3.2.2",
-      "dev": true,
-      "requires": {
-        "@exodus/schemasafe": "^1.0.0-rc.2",
-        "should": "^13.2.1",
-        "yaml": "^1.10.0"
-      },
-      "dependencies": {
-        "yaml": {
-          "version": "1.10.2",
-          "dev": true
-        }
-      }
-    },
-    "oas-resolver": {
-      "version": "2.5.6",
-      "dev": true,
-      "requires": {
-        "node-fetch-h2": "^2.3.0",
-        "oas-kit-common": "^1.0.8",
-        "reftools": "^1.1.9",
-        "yaml": "^1.10.0",
-        "yargs": "^17.0.1"
-      },
-      "dependencies": {
-        "yaml": {
-          "version": "1.10.2",
-          "dev": true
-        }
-      }
-    },
-    "oas-schema-walker": {
-      "version": "1.1.5",
-      "dev": true
-    },
-    "oas-validator": {
-      "version": "5.0.8",
-      "dev": true,
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "oas-kit-common": "^1.0.8",
-        "oas-linter": "^3.2.2",
-        "oas-resolver": "^2.5.6",
-        "oas-schema-walker": "^1.1.5",
-        "reftools": "^1.1.9",
-        "should": "^13.2.1",
-        "yaml": "^1.10.0"
-      },
-      "dependencies": {
-        "yaml": {
-          "version": "1.10.2",
-          "dev": true
-        }
-      }
-    },
     "object-assign": {
       "version": "4.1.1",
       "dev": true
@@ -13728,48 +13168,6 @@
       "requires": {
         "mimic-fn": "^2.1.0"
       }
-    },
-    "openapi-forge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/openapi-forge/-/openapi-forge-1.0.1.tgz",
-      "integrity": "sha512-fzUQsa0dPt14cg2MhWgRKkMOBq4dV+QnoEyVKsbVL8vAjQwVrKiag2DJQZ6pGPggK0CwXsg6k4DrIscOVd+4uw==",
-      "dev": true,
-      "requires": {
-        "@apidevtools/swagger-parser": "^10.1.0",
-        "commander": "^9.2.0",
-        "handlebars": "^4.7.7",
-        "minimatch": "^5.1.0",
-        "node-fetch": "^2.6.7",
-        "prettier": "^2.7.1",
-        "shelljs": "^0.8.5",
-        "swagger2openapi": "^7.0.8",
-        "yaml": "^2.1.1"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "commander": {
-          "version": "9.3.0",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "5.1.0",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
-      }
-    },
-    "openapi-types": {
-      "version": "12.0.2",
-      "dev": true,
-      "peer": true
     },
     "optionator": {
       "version": "0.9.1",
@@ -14135,13 +13533,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -14168,10 +13559,6 @@
       "requires": {
         "esprima": "~4.0.0"
       }
-    },
-    "reftools": {
-      "version": "1.1.9",
-      "dev": true
     },
     "regenerator-runtime": {
       "version": "0.13.9",
@@ -14419,57 +13806,6 @@
       "version": "1.0.0",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.8.5",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
-    },
-    "should": {
-      "version": "13.2.3",
-      "dev": true,
-      "requires": {
-        "should-equal": "^2.0.0",
-        "should-format": "^3.0.3",
-        "should-type": "^1.4.0",
-        "should-type-adaptors": "^1.0.1",
-        "should-util": "^1.0.0"
-      }
-    },
-    "should-equal": {
-      "version": "2.0.0",
-      "dev": true,
-      "requires": {
-        "should-type": "^1.4.0"
-      }
-    },
-    "should-format": {
-      "version": "3.0.3",
-      "dev": true,
-      "requires": {
-        "should-type": "^1.3.0",
-        "should-type-adaptors": "^1.0.1"
-      }
-    },
-    "should-type": {
-      "version": "1.4.0",
-      "dev": true
-    },
-    "should-type-adaptors": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "should-type": "^1.3.0",
-        "should-util": "^1.0.0"
-      }
-    },
-    "should-util": {
-      "version": "1.0.1",
-      "dev": true
-    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -14624,10 +13960,6 @@
         }
       }
     },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "dev": true
-    },
     "stack-chain": {
       "version": "2.0.0",
       "dev": true
@@ -14758,29 +14090,6 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "dev": true
-    },
-    "swagger2openapi": {
-      "version": "7.0.8",
-      "dev": true,
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "node-fetch": "^2.6.1",
-        "node-fetch-h2": "^2.3.0",
-        "node-readfiles": "^0.2.0",
-        "oas-kit-common": "^1.0.8",
-        "oas-resolver": "^2.5.6",
-        "oas-schema-walker": "^1.1.5",
-        "oas-validator": "^5.0.8",
-        "reftools": "^1.1.9",
-        "yaml": "^1.10.0",
-        "yargs": "^17.0.1"
-      },
-      "dependencies": {
-        "yaml": {
-          "version": "1.10.2",
-          "dev": true
-        }
-      }
     },
     "temp-dir": {
       "version": "2.0.0",
@@ -15107,10 +14416,6 @@
     },
     "yallist": {
       "version": "4.0.0",
-      "dev": true
-    },
-    "yaml": {
-      "version": "2.1.1",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "prepare": "husky install",
     "test": "\"./node_modules/.bin/cucumber-js\" -p default",
-    "test:defaultPath": "\"./node_modules/.bin/cucumber-js\" -p default \"node_modules/openapi-forge/features/*.feature\" \"openapi-forge/src/generate\"",
+    "test:defaultPath": "\"./node_modules/.bin/cucumber-js\" -p default \"../openapi-forge/features/*.feature\" \"../../../openapi-forge/src/generate\"",
     "format:check:all": "prettier --check .",
     "format:write:all": "prettier --write .",
     "format:write": "prettier --write",
@@ -31,7 +31,6 @@
     "cucumber-tsflow": "^3.2.0",
     "eslint": "^8.24.0",
     "husky": "^8.0.1",
-    "openapi-forge": "latest",
     "semantic-release": "^19.0.5",
     "ts-node": "^8.0.3",
     "typescript": "^4.7.4"


### PR DESCRIPTION
PR for issue: https://github.com/ScottLogic/openapi-forge/issues/129

Remove dependency on openapi-forge in generator and enforce the use of the global forge.

This simplifies testing considerably as a misuse of global/local & version differences cannot happen.