### PR TITLE
fix: formatter is now a JS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ https://github.com/ScottLogic/openapi-forge
 
 To run this generator, you also need to have [OpenAPI Forge] installed, or the repository checked out. Assuming you have it installed as a global module, you can run this generator as follows:
 
-~~~
+```
 $ openapi-forge forge
  \ https://petstore3.swagger.io/api/v3/openapi.json
  \ .
  \ -o api
-~~~
+```
 
 This generates an API from the Pet Store swagger definition, using the generator within the current folder (`.`), outputting the results to the `api` folder.
 

--- a/formatter.js
+++ b/formatter.js
@@ -1,0 +1,18 @@
+// there are issues with running prettier as a CLI command
+// see: https://github.com/ScottLogic/openapi-forge/issues/133
+// this is a workaround to run the prettier CLI as a node module
+const cli = require("prettier/cli.js");
+
+// map forge log levels to prettier log levels
+const logLevels = [
+  /* quiet */
+  "silent",
+  /* standard */
+  "warn",
+  /* verbose */
+  "debug",
+];
+
+module.exports = (folder, logLevel) => {
+  cli.run(["--write", folder, "--loglevel", logLevels[logLevel]]);
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test:generators": "\"./node_modules/.bin/cucumber-js\" -p generators",
     "format:check:all": "prettier --check .",
     "format:write:all": "prettier --write .",
-    "format:write": "prettier --write",
     "lint:check:all": "eslint .",
     "lint:write:all": "eslint --fix ."
   },


### PR DESCRIPTION
workaround for https://github.com/ScottLogic/openapi-forge/issues/133 - will avoid the need to run cd via the shell