### PR TITLE
Add support for response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const api = new ApiPet(config);
   });
 
   const pet = await api.getPetById(1);
-  console.log(pet.name);
+  console.log(pet.data.name);
 })();
 ```
 

--- a/features/support/api.ts
+++ b/features/support/api.ts
@@ -138,17 +138,17 @@ export class ModelSteps extends BaseModelStep {
 
   @then(/the response should be of type (.*)/)
   public checkResponseType(type: string) {
-    assert.equal(this.apiResponse.constructor.name, type);
+    assert.equal(this.apiResponse.data.constructor.name, type);
   }
 
   @then(/the response should be equal to "(.*)"/)
   public checkResponseValue(value: string) {
-    assert.equal(this.apiResponse, value);
+    assert.equal(this.apiResponse.data, value);
   }
 
   @then(/the response should have a property ([a-zA-Z]*) with value (.*)/)
   public checkResponseProperty(propName: string, propValue: string) {
-    const value = this.apiResponse[propName];
+    const value = this.apiResponse.data[propName];
     const formattedValue =
       value instanceof Date ? value.toISOString() : value.toString();
     assert.equal(formattedValue, propValue);
@@ -156,12 +156,12 @@ export class ModelSteps extends BaseModelStep {
 
   @then(/the response should be an array/)
   public checkArrayResponse() {
-    assert.isArray(this.apiResponse);
+    assert.isArray(this.apiResponse.data);
   }
 
   @when(/extracting the object at index ([0-9]*)/)
   public extractAtIndex(index: string) {
-    this.apiResponse = this.apiResponse[parseInt(index)];
+    this.apiResponse.data = this.apiResponse.data[parseInt(index)];
   }
 
   @then(/the request method should be of type (.*)/)

--- a/features/support/api.ts
+++ b/features/support/api.ts
@@ -22,6 +22,7 @@ export class ModelSteps extends BaseModelStep {
   private requestParams: RequestParameters;
   private apiResponse: any;
   private serverResponseObject: any;
+  private serverResponseHeaders: any;
   private api: any;
   private request: any;
 
@@ -32,8 +33,9 @@ export class ModelSteps extends BaseModelStep {
       const mockTransport = async (params: RequestParameters) => {
         this.requestParams = params;
         return {
-          data: this.serverResponseObject
-        }
+          data: this.serverResponseObject,
+          headers: this.serverResponseHeaders,
+        };
       };
 
       const config = new configurationModule.default(mockTransport);
@@ -48,6 +50,7 @@ export class ModelSteps extends BaseModelStep {
   @after()
   public async after() {
     this.serverResponseObject = undefined;
+    this.serverResponseHeaders = undefined;
     this.apiResponse = undefined;
 
     return this.cleanup();
@@ -132,10 +135,22 @@ export class ModelSteps extends BaseModelStep {
     assert.isNull(this.apiResponse.data);
   }
 
-  @when(/calling the method ([a-zA-Z]*) and the server responds with/)
+  @when(/calling the method ([a-zA-Z]*) and the server responds with$/)
   public async callWithResponse(methodName: string, response: string) {
     this.serverResponseObject = JSON.parse(response);
     this.apiResponse = await this.api[methodName]();
+  }
+
+  @when(/calling the method ([a-zA-Z]*) and the server responds with headers$/)
+  public async callWithResponseHeaders(methodName: string, headers: string) {
+    this.serverResponseObject = {};
+    this.serverResponseHeaders = JSON.parse(headers);
+    this.apiResponse = await this.api[methodName]();
+  }
+
+  @then(/the response should have a header (.*) with value (.*)/)
+  public checkResponseHeader(prop: string, value: string) {
+    assert.equal(this.apiResponse.headers[prop], value);
   }
 
   @then(/the response should be of type (.*)/)

--- a/features/support/api.ts
+++ b/features/support/api.ts
@@ -31,7 +31,9 @@ export class ModelSteps extends BaseModelStep {
       const configurationModule = require("../api/configuration.ts");
       const mockTransport = async (params: RequestParameters) => {
         this.requestParams = params;
-        return this.serverResponseObject;
+        return {
+          data: this.serverResponseObject
+        }
       };
 
       const config = new configurationModule.default(mockTransport);
@@ -127,7 +129,7 @@ export class ModelSteps extends BaseModelStep {
 
   @then(/the response should be null/)
   public checkResponseIsNull() {
-    assert.isNull(this.apiResponse);
+    assert.isNull(this.apiResponse.data);
   }
 
   @when(/calling the method ([a-zA-Z]*) and the server responds with/)

--- a/template/api.ts.handlebars
+++ b/template/api.ts.handlebars
@@ -44,7 +44,7 @@ export default class Api{{_tag.name}} {
           {{typeConvert schema ../../../_options}}
           {{#if schema.default}} = {{{quoteIfString schema.default}}}{{/if}},
         {{/each}}
-      ): Promise<{{#if _response.schema}}HttpResponse<{{typeConvert _response.schema ../../_options}}>{{else}}null{{/if}}> {
+      ): Promise<HttpResponse<{{#if _response.schema}}{{typeConvert _response.schema ../../_options}}{{else}}any{{/if}}>> {
 
         const builder = new ParameterBuilder();
         {{#each _sortedParameters}}{{#unless _optional}}
@@ -60,10 +60,11 @@ export default class Api{{_tag.name}} {
         const response = await request(this.config, "{{@root.path}}", "{{@key}}", builder.parameters);
         {{#if _response.schema}}
         return {
-          data: deserialize(response, "{{typeConvert _response.schema}}")
+          ... response,
+          data: deserialize(response.data, "{{typeConvert _response.schema}}")
         };
         {{else}}
-        return null;
+        return response;
         {{/if}}
       };
     {{/ifEquals}}

--- a/template/api.ts.handlebars
+++ b/template/api.ts.handlebars
@@ -2,6 +2,7 @@ import Configuration from "./configuration";
 {{>modelIncludes models=components.schemas options=_options}}
 {{>modelIncludes models=components.inlineObjects options=_options}}
 import { request } from "./request";
+import { HttpResponse } from "./response";
 import { Parameter, ParameterBuilder } from "./parameterBuilder";
 import { deserialize, serialize } from "./serializer";
 
@@ -43,7 +44,7 @@ export default class Api{{_tag.name}} {
           {{typeConvert schema ../../../_options}}
           {{#if schema.default}} = {{{quoteIfString schema.default}}}{{/if}},
         {{/each}}
-      ): Promise<{{#if _response.schema}}{{typeConvert _response.schema ../../_options}}{{else}}null{{/if}}> {
+      ): Promise<{{#if _response.schema}}HttpResponse<{{typeConvert _response.schema ../../_options}}>{{else}}null{{/if}}> {
 
         const builder = new ParameterBuilder();
         {{#each _sortedParameters}}{{#unless _optional}}
@@ -58,7 +59,9 @@ export default class Api{{_tag.name}} {
 
         const response = await request(this.config, "{{@root.path}}", "{{@key}}", builder.parameters);
         {{#if _response.schema}}
-        return deserialize(response, "{{typeConvert _response.schema}}");
+        return {
+          data: deserialize(response, "{{typeConvert _response.schema}}")
+        };
         {{else}}
         return null;
         {{/if}}

--- a/template/configuration.ts.handlebars
+++ b/template/configuration.ts.handlebars
@@ -1,10 +1,11 @@
 import { RequestParameters } from "./request";
+import { HttpResponse } from "./response";
 
 /**
  * A function which performs a request to the API.
  */
-export interface TransportFunc {
-  (request: RequestParameters): Promise<any>;
+export interface Transport {
+  (request: RequestParameters): Promise<HttpResponse<any>>;
 }
 
 /**
@@ -29,9 +30,9 @@ export default class Configuration {
    */
   public basePath?: string;
   public bearerToken?: string;
-  public transport: TransportFunc;
+  public transport: Transport;
 
-  constructor(transport: TransportFunc) {
+  constructor(transport: Transport) {
     this.transport = transport;
   }
 }

--- a/template/fetch.ts
+++ b/template/fetch.ts
@@ -2,8 +2,8 @@ import { RequestParameters } from "./request";
 import { Transport } from "../api/configuration";
 
 const parseHeaders = (headers: Headers) => {
-  let res: Record<string, string> = {};
-  for (let [key, value] of headers.entries()) {
+  const res: Record<string, string> = {};
+  for (const [key, value] of headers.entries()) {
     res[key] = value;
   }
   return res;

--- a/template/fetch.ts
+++ b/template/fetch.ts
@@ -1,9 +1,30 @@
 import { RequestParameters } from "./request";
+import { Transport } from "../api/configuration";
 
-export default async function transport(params: RequestParameters) {
-  const response = await fetch(params.url, params);
-  if (response.status !== 200) {
-    throw new Error(`${response.status} ${response.statusText}`);
+const parseHeaders = (headers: Headers) => {
+  let res: Record<string, string> = {};
+  for (let [key, value] of headers.entries()) {
+    res[key] = value;
   }
-  return await response.json();
-}
+  return res;
+};
+
+const transport: Transport = async function (params: RequestParameters) {
+  const fetchResponse = await fetch(params.url, params);
+
+  if (fetchResponse.ok) {
+    const json = await fetchResponse.json();
+    return {
+      data: json,
+      statusCode: fetchResponse.status,
+      headers: parseHeaders(fetchResponse.headers),
+      type: fetchResponse.type,
+    };
+  } else {
+    throw new Error(
+      `Error ${fetchResponse.status}: ${fetchResponse.statusText}`
+    );
+  }
+};
+
+export default transport;

--- a/template/request.ts
+++ b/template/request.ts
@@ -1,15 +1,14 @@
 import Configuration from "./configuration";
 import { Parameter } from "./parameterBuilder";
+import { HttpResponse } from "./response";
 
-export interface Headers {
-  [index: string]: string;
-}
+type Headers = Record<string, string>;
 
 export interface RequestParameters {
   url: string;
   method: string;
   body?: string;
-  headers: Headers;
+  headers: Record<string, string>;
 }
 
 export async function request(
@@ -17,7 +16,7 @@ export async function request(
   path: string,
   method: string,
   params: Parameter[]
-): Promise<any> {
+): Promise<HttpResponse<any>> {
   // replace path parameters with values
   for (const pathParam of params.filter((p) => p.location === "path")) {
     path = path.replace(

--- a/template/response.ts
+++ b/template/response.ts
@@ -23,6 +23,6 @@ export interface HttpResponse<T> {
   /**
    * The type of the response (e.g., basic, cors).
    * @type string
-   */ 
+   */
   type: string;
 }

--- a/template/response.ts
+++ b/template/response.ts
@@ -2,8 +2,27 @@
  * The response of a HTTP request, contains both the response data and associated metadata.
  */
 export interface HttpResponse<T> {
+  /**
+   * The response data.
+   * @type T
+   */
   data: T;
+
+  /**
+   * The response status code.
+   * @type number
+   */
   statusCode: number;
+
+  /**
+   * The response headers.
+   * @type Record<string, string>
+   */
   headers: Record<string, string>;
+
+  /**
+   * The type of the response (e.g., basic, cors).
+   * @type string
+   */ 
   type: string;
 }

--- a/template/response.ts
+++ b/template/response.ts
@@ -1,0 +1,6 @@
+/**
+ * The response of a HTTP request, contains both the response data and associated metadata.
+ */
+export interface HttpResponse<T> {
+  data: T;
+} 

--- a/template/response.ts
+++ b/template/response.ts
@@ -3,4 +3,7 @@
  */
 export interface HttpResponse<T> {
   data: T;
-} 
+  statusCode: number;
+  headers: Record<string, string>;
+  type: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "target": "ES5",
+    "target": "ES6",
     "noImplicitAny": true
   }
 }


### PR DESCRIPTION
Partially implements https://github.com/ScottLogic/openapi-forge/issues/77 by exposing response headers, but does not apply the type information that may be present in the schema