### PR TITLE
fix: indicate that required properties are not null

### DIFF
--- a/partials/model.handlebars
+++ b/partials/model.handlebars
@@ -18,6 +18,6 @@ export class {{@key}} {
   ];
 
   {{#each properties}}
-    public {{@key}}{{#unless _required}}?{{/unless}}: {{typeConvert this}};
+    public {{@key}}{{#if _required}}!{{else}}?{{/if}}: {{typeConvert this}};
   {{/each}}
 }


### PR DESCRIPTION
The code which is generated results in the following errors:

> error TS2564: Property 'name' has no initializer and is not definitely assigned in the constructor. 

Because the model objects are deserialised from JSON, it is not possible to create TS classes that demonstrate to the compiler that these properties are always set. 

This change uses the null assertion operator to indicate that this value is not null:

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator