### PR TITLE
feat: required properties are supplied via a constructor function

### DIFF
--- a/partials/model.handlebars
+++ b/partials/model.handlebars
@@ -8,11 +8,12 @@
  */
 export class {{@key}} {
 
-  static propertyTypes: Array<{name: string, type: string}> =  [
+  static propertyTypes: Array<PropertyMetadata> =  [
     {{#each properties}}
       {
         name: "{{@key}}",
-        type: "{{typeConvert this}}"
+        type: "{{typeConvert this}}",
+        required: {{#if _required}}true{{else}}false{{/if}}
       },
     {{/each}}
   ];
@@ -20,4 +21,11 @@ export class {{@key}} {
   {{#each properties}}
     public {{@key}}{{#unless _required}}?{{/unless}}: {{typeConvert this}};
   {{/each}}
+
+  constructor(
+    {{#each properties}}{{#if _required}}{{@key}}: {{typeConvert this}},{{/if}}{{/each}}
+  ) {
+    {{#each properties}}{{#if _required}}
+      this.{{@key}} = {{@key}};{{/if~}}{{/each~}}
+  }
 }

--- a/template/model.ts.handlebars
+++ b/template/model.ts.handlebars
@@ -1,3 +1,9 @@
+export interface PropertyMetadata {
+  name: string,
+  type: string,
+  required: boolean
+}
+
 {{#each components.schemas}}
 {{> model}}
 

--- a/template/serializer.ts.handlebars
+++ b/template/serializer.ts.handlebars
@@ -1,7 +1,9 @@
 {{#if _options.testRun }}
 const model = require("./model");
+const PropertyMetadata = model.PropertyMetadata;
 {{else}}
 import * as model from "./model";
+import { PropertyMetadata } from "./model";
 {{/if}}
 
 // takes a JSON response and deserializes it into the required model objects / types
@@ -15,9 +17,17 @@ export function deserialize(json: any, type: string): any {
 
   // handle model objects
   if (model.models.includes(type)) {
-    const modelObject = new (<any>model)[type]();
+    // get the required and optional properties
     const properties = (<any>model)[type].propertyTypes;
-    for (const property of properties) {
+    const requiredProperties = properties.filter((property: {{#if _options.testRun }}typeof {{/if}}PropertyMetadata ) => property.required);
+    const optionalProperties = properties.filter((property: {{#if _options.testRun }}typeof {{/if}}PropertyMetadata) => !property.required);
+    const requiredPropertyValues = requiredProperties.map((property: {{#if _options.testRun }}typeof {{/if}}PropertyMetadata) => deserialize(json[property.name], property.type));
+
+    // create the model object
+    const modelObject = new (<any>model)[type](...requiredPropertyValues);
+    
+    // set the optional properties
+    for (const property of optionalProperties) {
       if (json[property.name] !== undefined) {
         modelObject[property.name] = deserialize(json[property.name], property.type);
       }


### PR DESCRIPTION
@OiNutter based on your suggestions on this PR #50 - this is an alternative implementation where constructors are used for required properties. 

The debate about interfaces / classes aside (#51), I do think this is a cleaner way to handle required properties.